### PR TITLE
fix #5 ; Support non-macos UNIX like environments such as Linux

### DIFF
--- a/nj-build/src/lib.rs
+++ b/nj-build/src/lib.rs
@@ -2,5 +2,7 @@
 /// configure linker to generate node.js dynamic library
 pub fn configure() {
     println!("cargo:rustc-cdylib-link-arg=-undefined");
-    println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    if cfg!(macos) {
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
 }


### PR DESCRIPTION
related: #5 

`examples/function` works 👍  in my Arch Linux (WSL2) environment:

```sh
node
Welcome to Node.js v13.12.0.
Type ".help" for more information.
> a = require('./dist')
{}
> a.hello()
Uncaught TypeError: 1 args expected but 0 is present
> a.hello('nj')
Uncaught TypeError: invalid type, expected: number, actual: string
> a.hello(123)
'hello world 123'
>
```