### PR TITLE
fix #18, bool value is integer in js

### DIFF
--- a/nj-core/src/basic.rs
+++ b/nj-core/src/basic.rs
@@ -165,6 +165,17 @@ impl JsEnv {
         Ok(result)
     }
 
+    pub fn create_boolean(&self,value: bool) -> Result<napi_value,NjError>  {
+        let mut result = ptr::null_mut();
+        napi_call_result!(
+            crate::sys::napi_get_boolean(
+                self.0,
+                value,
+                &mut result,
+            )
+        )?;
+        Ok(result)
+    }
 
 
     pub fn get_global(&self) -> Result<napi_value,NjError> {

--- a/nj-core/src/convert.rs
+++ b/nj-core/src/convert.rs
@@ -16,12 +16,7 @@ pub trait TryIntoJs {
 
 impl TryIntoJs for bool {
     fn try_to_js(self, js_env: &JsEnv) -> Result<napi_value,NjError> {
-        if self {
-            js_env.create_int32(1)
-        } else {
-            js_env.create_int32(0)
-        }
-       
+        js_env.create_boolean(self)
     }   
 }
 


### PR DESCRIPTION
related: #18 

```rust
use node_bindgen::derive::node_bindgen;

#[node_bindgen]
pub fn foo() -> bool {
    true
}
```
```js
const addon = require('./dist')
console.log(addon.foo()) // true
```


