### PR TITLE
Capture extra arguments beyond `nj-cli build` to forward to cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target-docker
 .vscode/tasks.json
 dist
 dylib
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "nj-core"
-version = "2.1.1"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "ctor",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "nj-derive"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/nj-cli/src/main.rs
+++ b/nj-cli/src/main.rs
@@ -27,7 +27,9 @@ enum Opt {
 struct BuildOpt {
 
     #[structopt(short = "o", long = "out", default_value = "dist")]
-    output: String
+    output: String,
+
+    extras: Vec<String>,
 }
 
 
@@ -46,8 +48,11 @@ fn main() {
 // kick off build
 fn build(opt: BuildOpt) {
 
+    let mut args = vec!["build".to_string()];
+    args.extend(opt.extras);
+
     let mut build_command = Command::new("cargo")
-        .arg("build")
+        .args(&args)
         .stdout(Stdio::inherit())
         .spawn()
         .expect("Failed to execute command");


### PR DESCRIPTION
Implements #48 

I added a field to `BuildOpt` to catch all of the positional arguments given to `nj-cli build`. Unfortunately, it seems that arguments are only considered "positional" if they appear beyond the `--`. So for example, if we wanted to call `cargo build --release`, the way we would capture that from nj-cli is as follows:

```
# Demonstrating using cargo run
nj-cli $ cargo run -- build -- --release # Here, --release appears after -- so it's captured as a positional argument
```

I feel like the ideal situation would allow us to do the following:

```
nj-cli $ cargo run -- build --release
```

Unfortunately in this case, `structopt` tries to parse `--release` as if it were a named argument, which fails to match any of the arguments defined in `BuildOpt`, causing the match to fail and causes `nj-cli` to print the usage message.