### PR TITLE
add delete_reference method to JsEnv; invoke after calling napi_wrap

### DIFF
--- a/nj-core/src/basic.rs
+++ b/nj-core/src/basic.rs
@@ -387,7 +387,7 @@ impl JsEnv {
         Ok(js_constructor)
     }
 
-    pub fn create_reference(&self, cons: napi_value,count: u32)  -> Result<napi_ref,NjError> {
+    pub fn create_reference(&self, cons: napi_value,count: u32) -> Result<napi_ref,NjError> {
         
         let mut result = ptr::null_mut();
         napi_call_result!(
@@ -402,6 +402,9 @@ impl JsEnv {
         Ok(result)
     }
 
+    pub fn delete_reference(&self, ref_: napi_ref) -> Result<(), NjError> {
+        Ok(napi_call_result!(crate::sys::napi_delete_reference(self.0, ref_))?)
+    }
 
     pub fn get_new_target(&self, info: napi_callback_info) -> Result<napi_value,NjError> {
 

--- a/nj-core/src/class.rs
+++ b/nj-core/src/class.rs
@@ -47,6 +47,15 @@ impl <T>JSObjectWrapper<T> where T: JSClass {
             rust_ref.wrapper = wrap;
         }
 
+        // Finally, remove the reference in response to finalize callback
+        // See footnote on `napi_wrap` documentation: https://nodejs.org/api/n-api.html#n_api_napi_wrap
+        // 
+        // "Caution: The optional returned reference (if obtained) should be deleted via napi_delete_reference 
+        // ONLY in response to the finalize callback invocation. If it is deleted before then, 
+        // then the finalize callback may never be invoked. Therefore, when obtaining a reference a 
+        // finalize callback is also required in order to enable correct disposal of the reference."
+        js_env.delete_reference(wrap);
+
         Ok(js_cb.this_owned())
     }
 }
@@ -153,7 +162,7 @@ pub trait JSClass: Sized {
         debug!("my object finalize");
         unsafe {
             let ptr: *mut JSObjectWrapper<Self> = finalize_data as *mut JSObjectWrapper<Self>;
-            let _rust = Box::from_raw(ptr);
+            Box::from_raw(ptr);
         }
         
     }


### PR DESCRIPTION
This PR rebases the works in #55 on master to separate build errors in the `support_v4` branch. Notably, this PR removes the cargo.lock changes, only changing the code in question. This code has also been tested to reproduce the desired result.