### PR TITLE
add nj-cli init command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
 name = "nj-build"
 version = "0.2.0"
 dependencies = [
+ "cc",
  "reqwest",
 ]
 

--- a/nj-cli/Cargo.lock
+++ b/nj-cli/Cargo.lock
@@ -65,7 +65,9 @@ version = "0.3.0"
 dependencies = [
  "cargo_metadata",
  "log",
+ "serde",
  "structopt",
+ "toml",
 ]
 
 [[package]]
@@ -131,6 +133,9 @@ name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -205,6 +210,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/nj-cli/Cargo.toml
+++ b/nj-cli/Cargo.toml
@@ -13,3 +13,5 @@ license = "Apache-2.0"
 log = "0.4.8"
 structopt = { version = "0.2.14", default-features = false }
 cargo_metadata = "0.9.1"
+toml = "0.5.6"
+serde = { version = "1.0.114", features = ["derive"] }

--- a/nj-cli/src/init/mod.rs
+++ b/nj-cli/src/init/mod.rs
@@ -1,0 +1,3 @@
+mod project_files;
+
+pub use project_files::{ProjectFiles};

--- a/nj-cli/src/init/project_files.rs
+++ b/nj-cli/src/init/project_files.rs
@@ -1,0 +1,137 @@
+use std::path::PathBuf;
+use std::fs::{File, remove_file, read_to_string};
+use std::io::Write;
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Config {
+    package: ConfigPackage,
+    lib: Option<ConfigLib>,
+    dependencies: Option<Dependencies>,
+    build_dependencies: Option<Dependencies>
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ConfigPackage {
+    name: String,
+    version: String,
+    authors: Vec<String>,
+    edition: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ConfigLib {
+    #[serde(rename = "crate-type")]
+    crate_type: Vec<String>
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Dependencies {
+    #[serde(rename = "node-bindgen")]
+    node_bindgen: Option<Dependency>
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Dependency {
+    version: String,
+    features: Vec<String>
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectFiles {
+    dir: PathBuf
+}
+
+impl ProjectFiles {
+    pub fn new(dir: PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self { 
+            dir 
+        }
+        .add_build_rs()?
+        .add_lib_rs()?
+        .add_cargo_toml()?)
+    }
+
+    fn add_build_rs(self) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut build_rs = self.dir.clone();
+        build_rs.push("build.rs");
+        
+        let mut file = File::create(&build_rs)?;
+        file.write_all(b"fn main() { 
+            node_bindgen::build::configure(); 
+        }")?;
+
+        Ok(self)
+    }
+
+    fn add_lib_rs(self) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut lib_rs = self.dir.clone();
+        lib_rs.push("src/lib.rs");
+
+        // remove existing file, if exists;
+        if lib_rs.exists() {
+            remove_file(&lib_rs)?;
+        }
+
+        const LIB_RS: &str = r##"
+            use node_bindgen::derive::node_bindgen;
+            
+            struct MyObject {}
+
+            #[node_bindgen]
+            impl MyObject {
+            
+                #[node_bindgen(constructor)]
+                fn new() -> Self {
+                    Self {}
+                }
+
+                #[node_bindgen(name = "hello")]
+                fn hello(&self) -> String {
+                    "world".to_string()
+                }
+            }
+        "##;
+
+        let mut file = File::create(&lib_rs)?;
+        file.write_all(LIB_RS.as_bytes())?;
+
+        Ok(self)
+    }
+
+    fn add_cargo_toml(self) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut cargo_toml = self.dir.clone();
+        cargo_toml.push("Cargo.toml");
+
+        let mut config: Config = toml::from_str(&read_to_string(&cargo_toml)?)?;
+
+        // NOTE: Attempt to get the workspace version instead of this hard coded value;
+        let version = "2.1.1".to_string();
+
+        config.lib = Some(ConfigLib {
+            crate_type: vec!["cdylib".to_string()]
+        });
+        
+        config.dependencies = Some(Dependencies {
+            node_bindgen: Some(Dependency {
+                version: version.clone(),
+                features: vec![]
+            })
+        });
+        
+        config.build_dependencies = Some(Dependencies {
+            node_bindgen: Some(Dependency {
+                version,
+                features: vec!["build".to_string()]
+            })
+        });
+
+        // Remove the old cargo toml file;
+        remove_file(&cargo_toml)?;
+
+        let mut file = File::create(cargo_toml)?;
+        file.write_all(toml::to_string(&config)?.as_bytes())?;
+
+        Ok(self)
+    }
+
+}


### PR DESCRIPTION
Adds `nj-cli init <project name>` command for initialization of node-bindgen projects.

Resolves: #52 