### PR TITLE
Feature/ci/publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,26 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
 jobs:
+  version_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install cargo-cvm
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-cvm
+          version: latest
+      - name: Check Versions
+        run: cargo cvm -x
   clippy_check:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly, stable]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v1
       - name: Cancel Workflow Action
@@ -28,7 +40,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets --all-features -- -D warnings
-
   smoke_test:
     name: Smoke test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Tag, Build, Release and Publish
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  release_cli:
+    name: Build nj-cli
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: nj-cli
+            asset_name: nj-cli-linux-amd64
+          - os: macos-latest
+            artifact_name: nj-cli
+            asset_name: nj-cli-macos-amd64
+          - os: windows-latest
+            artifact_name: nj-cli.exe
+            asset_name: nj-cli.exe
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build nj-cli
+        run: cargo build --manifest-path nj-cli/Cargo.toml
+      - name: Upload binary to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: nj-cli/target/release/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}
+  publish_crates:
+    name: Publish to Crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-publish-all
+          version: latest
+      - run: cargo-publish-all --dry-run
+      - run: cargo-publish-all --token ${{ secrets.CRATES_TOKEN }} --yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,13 @@ If you’d like to implement a new feature, please consider creating a `feature 
 
 ### Releasing New Versions
 
-By default, when `master` branch is merged into `release` branch, this automatically will bump the version of the package, tag the new version, build the binary for release and publish the crate to crates.io.
+When a tagged branch with `v*` is pushed, a new release with that reference will be created and all crates in the workspace will be automatically published to crates.io. See the note below about version management.
 
 #### Versioning
 
-when opening a PR to merge `master` to `release`, ensure the commit message includes `#major`, `#minor` or `#patch` to handle the versioning correctly.
+Version control is handled by the CI workflow using `cargo cvm -x` to check against the `master` or target branch. If the version has not been updated, the CI will error with a message of which crate(s) have outdated versions. If a version is outdated, the developer can run `cargo cvm -f -s [`major`, `minor` or `patch`]` to automatically bump the crate's version. 
+
+> NOTE: If you run this in the workspace root, it will update all workspace crate versions. If this is not desired, run the command in the crate directory.
 
 ### License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ To suggest an enhancement, please create an issue on GitHub with the label `enha
 
 If you’d like to implement a new feature, please consider creating a `feature request` issue first to start a discussion about the feature.
 
+### Releasing New Versions
+
+By default, when `master` branch is merged into `release` branch, this automatically will bump the version of the package, tag the new version, build the binary for release and publish the crate to crates.io.
+
+#### Versioning
+
+when opening a PR to merge `master` to `release`, ensure the commit message includes `#major`, `#minor` or `#patch` to handle the versioning correctly.
+
 ### License
 
 This project is licensed under the [Apache license](LICENSE-APACHE). Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in Fluvio by you, shall be licensed as Apache, without any additional terms or conditions.


### PR DESCRIPTION
This PR runs the following steps on push to `release` (e.g. successful PR merge)

Added to the CI workflow:
1. Checks out the branch, checks if the version is fresh;

Adds a release workflow:
1. Builds the latest tagged version; Requires pushing a tagged release `v*`;
2. Releases the newly built tagged version;
3. Publishes on release the crate to crates.io;
