### PR TITLE
Fix race conditions with functions returning "no output"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-bindgen"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 description = "easy way to write nodejs module using rust"
@@ -18,7 +18,7 @@ build = ["nj-build"]
 nj-sys = { path = "nj-sys", version = "1.1.0", optional = true }
 nj-core = { path = "nj-core", version = "3.0.0", optional = true  }
 nj-build = { path = "nj-build", version = "0.2.1", optional = true }
-nj-derive = { path = "nj-derive", version = "2.1.0", optional = true}
+nj-derive = { path = "nj-derive", version = "2.1.1", optional = true}
 
 [workspace]
 members = [

--- a/nj-derive/Cargo.toml
+++ b/nj-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nj-derive"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["fluvio.io"]
 edition = "2018"
 description = "procedure macro for node-bindgen"

--- a/nj-derive/src/generator/context.rs
+++ b/nj-derive/src/generator/context.rs
@@ -5,7 +5,6 @@ use syn::FnArg;
 use syn::Signature;
 use syn::Receiver;
 use syn::LitStr;
-// use syn::ReturnType;
 use quote::quote;
 use proc_macro2::TokenStream;
 
@@ -52,14 +51,6 @@ impl <'a>FnGeneratorCtx<'a> {
     pub fn is_async(&self) -> bool {
         self.sig.asyncness.is_some()
     }
-
-    // /// check whether this function return ()
-    // pub fn has_default_output(&self) -> bool {
-    //     matches!(self.sig.output, ReturnType::Default)
-    // }
-
-
-    
 
     pub fn napi_fn_id(&self) -> Ident {
         ident(&format!("napi_{}", self.fn_name()))

--- a/nj-derive/src/generator/context.rs
+++ b/nj-derive/src/generator/context.rs
@@ -5,7 +5,7 @@ use syn::FnArg;
 use syn::Signature;
 use syn::Receiver;
 use syn::LitStr;
-use syn::ReturnType;
+// use syn::ReturnType;
 use quote::quote;
 use proc_macro2::TokenStream;
 
@@ -53,10 +53,11 @@ impl <'a>FnGeneratorCtx<'a> {
         self.sig.asyncness.is_some()
     }
 
-    /// check whether this function return ()
-    pub fn has_default_output(&self) -> bool {
-        matches!(self.sig.output, ReturnType::Default)
-    }
+    // /// check whether this function return ()
+    // pub fn has_default_output(&self) -> bool {
+    //     matches!(self.sig.output, ReturnType::Default)
+    // }
+
 
     
 

--- a/nj-derive/src/generator/function.rs
+++ b/nj-derive/src/generator/function.rs
@@ -114,29 +114,12 @@ pub fn generate_rust_invocation(ctx: &FnGeneratorCtx,cb_args: &mut CbArgs) -> To
     // if this is async, wrap with JsFuture
     let rust_invoke_ft_wrapper = if ctx.is_async() {
 
-        
-        if ctx.has_default_output() {
-
-            // since this doesn't have any output, we don't need return promise, we just
-            // spawn async and return null ptr
-            quote! {
-
-                node_bindgen::core::future::spawn(async move {
-                    #rust_invoke.await;
-                });
-
-                Ok(std::ptr::null_mut())
-            }
-
-        } else {
-
-            let async_name = format!("{}_ft", ctx.fn_name());
-            let async_lit = LitStr::new(&async_name, Span::call_site());
-            quote! {
-                (node_bindgen::core::JsPromiseFuture::new(
-                    #rust_invoke,#async_lit
-                )).try_to_js(&js_env)
-            }
+        let async_name = format!("{}_ft", ctx.fn_name());
+        let async_lit = LitStr::new(&async_name, Span::call_site());
+        quote! {
+            (node_bindgen::core::JsPromiseFuture::new(
+                #rust_invoke, #async_lit
+            )).try_to_js(&js_env)
         }
         
 


### PR DESCRIPTION
The current implementation of `#[node_bindgen]` wrapping shim over `async fn` functions special cased those with no return value to return immediately. This meant that if such an `async fn` had a side-effect that following-up code wanted to observe, there would be a race condition whereby such code could observe causally-inconsistent state, leading to logic bugs.

Removing that special-cased branch seems to have fixed the issue.