### PR TITLE
Implement dynamic string size.

### DIFF
--- a/examples/function/src/lib.rs
+++ b/examples/function/src/lib.rs
@@ -4,20 +4,20 @@ use node_bindgen::core::NjError;
 
 
 #[node_bindgen()]
-fn hello(count: i32) -> String {        
+fn hello(count: i32) -> String {
     format!("hello world {}", count)
 }
 
 
 #[node_bindgen]
-fn sum(first: i32, second: i32) -> i32 {        
+fn sum(first: i32, second: i32) -> i32 {
     first + second
 }
 
 
 // throw error if first > second, otherwise return sum
 #[node_bindgen]
-fn min_max(first: i32, second: i32) -> Result<i32,NjError> {        
+fn min_max(first: i32, second: i32) -> Result<i32,NjError> {
     if first > second {
         Err(NjError::Other("first arg is greater".to_owned()))
     } else {
@@ -26,14 +26,14 @@ fn min_max(first: i32, second: i32) -> Result<i32,NjError> {
 }
 
 #[node_bindgen(name="multiply")]
-fn mul(first: i32,second: i32) -> i32 {        
-    first * second 
+fn mul(first: i32,second: i32) -> i32 {
+    first * second
 }
 
 
-/// add second if supplied 
+/// add second if supplied
 #[node_bindgen()]
-fn sum2(first: i32, second_arg: Option<i32>) -> i32 {        
+fn sum2(first: i32, second_arg: Option<i32>) -> i32 {
     if let Some(second) = second_arg {
         first + second
     } else {
@@ -41,3 +41,11 @@ fn sum2(first: i32, second_arg: Option<i32>) -> i32 {
     }
 }
 
+#[node_bindgen()]
+fn string(first: String, second_arg: Option<String>) -> String {
+    if let Some(second) = second_arg {
+        format!("{} {}", first, second)
+    } else {
+        first
+    }
+}

--- a/examples/function/test.js
+++ b/examples/function/test.js
@@ -1,30 +1,77 @@
+const crypto = require('crypto');
+
 let addon =require('./dist');
 const assert = require('assert');
 
-assert.equal(addon.hello(2),"hello world 2"); 
-
+assert.strictEqual(addon.hello(2),"hello world 2");
 
 assert.throws( () => addon.hello("hello"),{
     message: 'invalid type, expected: number, actual: string'
 });
 
-
-
 assert.throws(() => addon.hello(),{
     message: 'expected argument of type: i32'
-});       
+});
 
-assert.equal(addon.sum(1,2),3);
+assert.strictEqual(addon.sum(1,2),3);
 
 assert.throws( () => addon.minMax(10,0),{
-    message: 'first arg is greater',   
+    message: 'first arg is greater',
   });
 
-assert.equal(addon.minMax(1,2),3);
+assert.strictEqual(addon.minMax(1,2),3);
 
-assert.equal(addon.multiply(2,5),10);
+assert.strictEqual(addon.multiply(2,5),10);
 
-assert.equal(addon.sum2(10),10);
-assert.equal(addon.sum2(5,100),105);
+assert.strictEqual(addon.sum2(10),10);
+assert.strictEqual(addon.sum2(5,100),105);
+
+const stringShort = _generateForCustomCharacters(5);
+const stringMedium = _generateForCustomCharacters(100);
+const stringLong = _generateForCustomCharacters(2000);
+const strings = new Set([stringShort, stringMedium, stringLong]);
+
+assert.strictEqual(addon.string(stringShort), stringShort);
+assert.strictEqual(addon.string(stringMedium), stringMedium);
+assert.strictEqual(addon.string(stringLong), stringLong);
+
+for(const string1 in strings) {
+    for(const string2 in strings) {
+        assert.strictEqual(addon.string(string1), string2);
+    }
+}
 
 console.log("function tests succeed");
+
+/*
+ * attribution: https://github.com/sindresorhus/crypto-random-string
+ * MIT License
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+ */
+function _generateForCustomCharacters(length, characters) {
+    characters = characters || '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'.split('');
+	// Generating entropy is faster than complex math operations, so we use the simplest way
+	const characterCount = characters.length;
+	const maxValidSelector = (Math.floor(0x10000 / characterCount) * characterCount) - 1; // Using values above this will ruin distribution when using modular division
+	const entropyLength = 2 * Math.ceil(1.1 * length); // Generating a bit more than required so chances we need more than one pass will be really low
+	let string = '';
+	let stringLength = 0;
+
+	while (stringLength < length) { // In case we had many bad values, which may happen for character sets of size above 0x8000 but close to it
+		const entropy = crypto.randomBytes(entropyLength);
+		let entropyPosition = 0;
+
+		while (entropyPosition < entropyLength && stringLength < length) {
+			const entropyValue = entropy.readUInt16LE(entropyPosition);
+			entropyPosition += 2;
+			if (entropyValue > maxValidSelector) { // Skip values which will ruin distribution when using modular division
+				continue;
+			}
+
+			string += characters[entropyValue % characterCount];
+			stringLength++;
+		}
+	}
+
+	return string;
+}


### PR DESCRIPTION
Allows for strings of variable lengths to be passed in.

Since I didn't see any existing in-line comments, I did not add any.

I'm not sure what the safety implications are for using `Box` in this manner.  Here's a recent discussion that seems relevant: https://github.com/rust-lang/unsafe-code-guidelines/issues/157

Passing NULL into napi_get_value_string_utf8 will return the size of the string.

https://nodejs.org/api/n-api.html#n_api_napi_get_value_string_utf8

Adapted from example provided here: https://github.com/nodejs/node-addon-examples/pull/107/files#diff-8252f94e35e4da5136727f8d25a119308698c527d26c04f4dc71ce90ca8fc85b

That PR is in connection with this issue: https://github.com/nodejs/node-addon-examples/issues/83#issuecomment-518336077
