### PR TITLE
Refactor get_buffer_info.

### DIFF
--- a/nj-core/src/basic.rs
+++ b/nj-core/src/basic.rs
@@ -570,17 +570,26 @@ impl JsEnv {
         use std::slice;
         use crate::sys::napi_get_buffer_info;
 
+        let mut js_ref = ptr::null_mut();
+        napi_call_result!(crate::sys::napi_create_reference(
+            self.0,
+            napi_value,
+            1,
+            &mut js_ref
+        ))?;
+
+        let mut val_ref = ptr::null_mut();
+        napi_call_result!(crate::sys::napi_get_reference_value(
+            self.0,
+            js_ref,
+            &mut val_ref
+        ))?;
+
         let mut len: size_t = 0;
         let mut data = ptr::null_mut();
-
-        //  napi_status napi_get_buffer_info(napi_env env,
-        //      napi_value value,
-        //      void** data,
-        //      size_t* length)
-
         napi_call_result!(napi_get_buffer_info(
             self.inner(),
-            napi_value,
+            val_ref,
             &mut data,
             &mut len
         ))?;


### PR DESCRIPTION
This is just for discussion to determine if there is any benefit here or not.  This is inspired by the warning about lifetimes in the `napi_get_buffer_info` documentation here: https://nodejs.org/api/n-api.html#n_api_napi_get_buffer_info

I gather that if `napi_create_reference`is used, the docs state that "the reference must be freed once it is no longer needed."

It's unclear to me when/if issues may arise from the existing implementation.

I thought the warning on this API was interesting as well: https://nodejs.org/api/n-api.html#n_api_napi_get_arraybuffer_info

This part seems interesting "It's also safe to use the returned data buffer within the same callback as long as there are no calls to other APIs that might trigger a GC." 

Maybe it's not applicable to a Rust implementation since a copy operation is required.