### PR TITLE
implement JSArrayBuffer that managed lifecyle of arraybuffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,12 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         override: true
-    - name: Unit tests
-      run:  cargo test
     - name: Install nj-cli build
       run:  cargo install nj-cli
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Test
-      run: make test
+    - name: All Tests
+      run: make test-all
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ## [4.1.0] - 2020-12-23
 
 # Improvements
-
 - Support for Dynamic Stream ([#110](https://github.com/infinyon/node-bindgen/pull/110))
 - Enforce Cargo fmt in CI ([#113](https://github.com/infinyon/node-bindgen/pull/113))
 

--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,3 @@ install-clippy:
 
 check-clippy:	install-clippy
 	cargo +$(RUSTV) clippy --all-targets  -- -D warnings
-	cd src/client; cargo +$(RUSTV) clippy --all-targets  -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ build-windows:
 	cargo build --target=x86_64-pc-windows-gnu
 
 
-test:	test-derive test-examples
-	
+test-all:	test-unit test-derive test-examples
+
+test-unit:
+	cargo test --lib --all-features
 
 test-examples:
 	make -C examples test	

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "nj-core"
-version = "4.0.0"
+version = "4.1.1"
 dependencies = [
  "async-trait",
  "ctor",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "nj-derive"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -940,7 +940,7 @@ version = "3.0.0"
 
 [[package]]
 name = "node-bindgen"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "nj-build",
  "nj-core",

--- a/examples/buffer/src/lib.rs
+++ b/examples/buffer/src/lib.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use node_bindgen::derive::node_bindgen;
-use node_bindgen::core::buffer::ArrayBuffer;
+use node_bindgen::core::buffer::{ArrayBuffer, JSArrayBuffer};
 use node_bindgen::core::NjError;
 
 #[derive(Serialize)]
@@ -65,13 +65,13 @@ fn test2(b: i32) -> Result<Record, NjError> {
 }
 
 #[node_bindgen]
-fn test3(data: &[u8]) -> Result<String, NjError> {
+fn test3(data: JSArrayBuffer) -> Result<String, NjError> {
     let message = String::from_utf8(data.to_vec())?;
     Ok(format!("reply {}", message))
 }
 
 #[node_bindgen]
-fn test4(first: &[u8], second: &[u8]) -> Result<String, NjError> {
+fn test4(first: JSArrayBuffer, second: JSArrayBuffer) -> Result<String, NjError> {
     let message1 = String::from_utf8(first.to_vec())?;
     let message2 = String::from_utf8(second.to_vec())?;
 

--- a/nj-core/src/buffer.rs
+++ b/nj-core/src/buffer.rs
@@ -87,8 +87,8 @@ impl<'a> JSValue<'a> for &'a [u8] {
 
 /// Rust representation of Nodejs [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)
 /// This is safe to pass around rest of Rust code since this manages Node.js GC lifecycle.
-/// JSArrayBuffer is deference as `&[u8]` 
-/// 
+/// JSArrayBuffer is deference as `&[u8]`
+///
 /// # Examples
 ///
 /// In this example, JS String is passed as array buffer.  Rust code convert to String and concate with prefix message.
@@ -96,14 +96,14 @@ impl<'a> JSValue<'a> for &'a [u8] {
 /// ```no_run
 /// use node_bindgen::derive::node_bindgen;
 /// use node_bindgen::core::buffer::JSArrayBuffer;
-/// 
+///
 /// #[node_bindgen]
 /// fn hello(data: JSArrayBuffer) -> Result<String, NjError> {
 ///   let message = String::from_utf8(data.to_vec())?;
 ///    Ok(format!("reply {}", message))
 /// }
 /// ```
-/// 
+///
 /// This can be invoked from Node.js
 /// ```text
 /// let addon = require('./your_module');

--- a/nj-core/src/buffer.rs
+++ b/nj-core/src/buffer.rs
@@ -5,7 +5,7 @@ use log::trace;
 
 use crate::TryIntoJs;
 use crate::JSValue;
-use crate::sys::{ napi_value,napi_ref,napi_env};
+use crate::sys::{napi_value, napi_ref, napi_env};
 use crate::val::JsEnv;
 use crate::NjError;
 
@@ -69,8 +69,6 @@ impl TryIntoJs for ArrayBuffer {
     }
 }
 
-
-
 impl<'a> JSValue<'a> for &'a [u8] {
     fn convert_to_rust(env: &'a JsEnv, js_value: napi_value) -> Result<Self, NjError> {
         // check if this is really buffer
@@ -87,38 +85,35 @@ impl<'a> JSValue<'a> for &'a [u8] {
     }
 }
 
-
 pub struct JSArrayBuffer {
     env: JsEnv,
     napi_ref: napi_ref,
-    buffer: &'static [u8]
+    buffer: &'static [u8],
 }
 
 impl JSValue<'_> for JSArrayBuffer {
-
     fn convert_to_rust(env: &JsEnv, napi_value: napi_value) -> Result<Self, NjError> {
         use std::mem::transmute;
 
-        let napi_ref = env.create_reference(napi_value.clone(),1)?;
+        let napi_ref = env.create_reference(napi_value, 1)?;
 
-        let buffer: &'static [u8] = unsafe  { 
-            transmute::<&[u8],&'static [u8]>(env.convert_to_rust(napi_value)?)
-        };
-        Ok(Self { 
-            env: env.clone(),
+        let buffer: &'static [u8] =
+            unsafe { transmute::<&[u8], &'static [u8]>(env.convert_to_rust(napi_value)?) };
+        Ok(Self {
+            env: *env,
             napi_ref,
-            buffer
+            buffer,
         })
     }
 }
 
-
 impl Drop for JSArrayBuffer {
     fn drop(&mut self) {
-        self.env.delete_reference(self.napi_ref).expect("reference can't be deleted to array buf");
+        self.env
+            .delete_reference(self.napi_ref)
+            .expect("reference can't be deleted to array buf");
     }
 }
-
 
 impl Deref for JSArrayBuffer {
     type Target = [u8];
@@ -127,6 +122,3 @@ impl Deref for JSArrayBuffer {
         &self.buffer
     }
 }
-
-
-


### PR DESCRIPTION
In the previous implementation, Nodejs `ArrayBuffer` is mapped as `&[u8]`.  This however doesn't allow lifecycle management of Nodejs ArrayBuffer.  It is possible that ArrayBuffer can be GC anytime.  

In this implementation, `JSArrayBuffer` manage lifecycle of ArrayBuffer directly.  When converting from JS, it creates references to Nodejs ArrayBuffer, preventing GC from occurring.   When it is dropped, it removes references allowing GC to occur