### PR TITLE
Added lifetime support to proc macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+### Improvements
+### Fixed
+
+## [4.2.1] - 2020-12-29
+### Improvements
+- Implement `JSValue` for `&str` ([#126](https://github.com/infinyon/node-bindgen/pull/126))
+- Add lifetime support for procedural macro ([#127](https://github.com/infinyon/node-bindgen/pull/127))
+### Fixed
 
 ## [4.1.1] - 2020-12-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "nj-derive"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "Inflector",
  "flv-future-aio",
@@ -1037,7 +1037,7 @@ version = "3.0.0"
 
 [[package]]
 name = "node-bindgen"
-version = "4.1.1"
+version = "4.2.1"
 dependencies = [
  "nj-build",
  "nj-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-bindgen"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 edition = "2018"
 description = "easy way to write nodejs module using rust"
@@ -18,7 +18,7 @@ build = ["nj-build"]
 nj-sys = { path = "nj-sys", version = "3.0.0", optional = true }
 nj-core = { path = "nj-core", version = "4.1.0", optional = true  }
 nj-build = { path = "nj-build", version = "0.2.1", optional = true }
-nj-derive = { path = "nj-derive", version = "3.0.0", optional = true}
+nj-derive = { path = "nj-derive", version = "3.0.1", optional = true}
 
 [workspace]
 members = [

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,10 @@ test-unit:
 	cargo test --lib --all-features
 
 test-examples:
-	make -C examples test	
+	make -C examples test
 
 test-derive:
-	cd nj-derive; RUST_LOG=debug cargo test derive_ui -- --nocapture
-
-test-try:
-	cd nj-derive; RUST_LOG=debug cargo test derive_try -- --nocapture
+	cd nj-derive; RUST_LOG=debug cargo test -- --nocapture
 
 
 #

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -940,7 +940,7 @@ version = "3.0.0"
 
 [[package]]
 name = "node-bindgen"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "nj-build",
  "nj-core",

--- a/nj-derive/Cargo.toml
+++ b/nj-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nj-derive"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["fluvio.io"]
 edition = "2018"
 description = "procedure macro for node-bindgen"

--- a/nj-derive/src/ast/types.rs
+++ b/nj-derive/src/ast/types.rs
@@ -21,6 +21,12 @@ impl<'a> MyTypePath<'a> {
     pub fn ident(&self) -> Option<&Ident> {
         self.0.name_identifier()
     }
+    pub fn lifetime(&self) -> Option<TokenStream> {
+        let ty = self.0.lifetime()?;
+        Some(quote! {
+            #ty
+        })
+    }
 
     pub fn expansion(&self) -> TokenStream {
         let ty = self.0;

--- a/nj-derive/src/ast/util.rs
+++ b/nj-derive/src/ast/util.rs
@@ -3,6 +3,9 @@ use syn::Ident;
 use syn::TypePath;
 use syn::ImplItemMethod;
 use syn::Attribute;
+use syn::PathArguments;
+use syn::Lifetime;
+use syn::GenericArgument;
 
 /// traits for function item
 pub trait FunctionItem {
@@ -17,6 +20,7 @@ impl FunctionItem for ItemFn {
 
 pub trait TypePathUtil {
     fn name_identifier(&self) -> Option<&Ident>;
+    fn lifetime(&self) -> Option<&Lifetime>;
 }
 
 impl TypePathUtil for TypePath {
@@ -27,6 +31,21 @@ impl TypePathUtil for TypePath {
             .iter()
             .find(|_| true)
             .map(|segment| &segment.ident)
+    }
+    /// find lifetime name.
+    fn lifetime(&self) -> Option<&Lifetime> {
+        let first = self.path.segments.first()?;
+        let lifetime_arg = if let PathArguments::AngleBracketed(arguments) = &first.arguments {
+            arguments.args.first()?
+        } else {
+            return None;
+        };
+        let lifetime = if let GenericArgument::Lifetime(lifetime) = lifetime_arg {
+            lifetime
+        } else {
+            return None;
+        };
+        Some(lifetime)
     }
 }
 

--- a/nj-derive/src/generator/class/mod.rs
+++ b/nj-derive/src/generator/class/mod.rs
@@ -32,7 +32,17 @@ fn generate_class_helper(class: Class) -> TokenStream {
     use arg::generate_class_arg;
 
     let constructor_method = class.constructor();
-    let type_name = class.self_ty.expansion();
+    let type_name = class.self_ty.ident().unwrap();
+    let lifetime = class.self_ty.lifetime();
+    let impl_for_block = if let Some(lifetime) = lifetime {
+        quote! {
+            #type_name<#lifetime>
+        }
+    } else {
+        quote! {
+            #type_name
+        }
+    };
 
     let helper_module_name = ident(&format!("{}_helper", type_name).to_lowercase());
 
@@ -55,7 +65,7 @@ fn generate_class_helper(class: Class) -> TokenStream {
 
             static mut CLASS_CONSTRUCTOR: node_bindgen::sys::napi_ref = ptr::null_mut();
 
-            impl node_bindgen::core::JSClass for #type_name {
+            impl node_bindgen::core::JSClass for #impl_for_block {
                 const CLASS_NAME: &'static str = #class_type_lit;
 
 

--- a/nj-derive/src/generator/function.rs
+++ b/nj-derive/src/generator/function.rs
@@ -133,10 +133,11 @@ pub fn generate_rust_invocation(ctx: &FnGeneratorCtx, cb_args: &mut CbArgs) -> T
 }
 
 /// generate rust value from js cb context
-///
-///     let js_cb = js_env.get_cb_info(cb_info, 2)?;
-///     let rust_value_0 = js_cb.get_value::<i32>(0)?;
-///     let rust_value_1 = js_cb.get_value::<i32>(1)?;
+/// ```ignore
+/// let js_cb = js_env.get_cb_info(cb_info, 2)?;
+/// let rust_value_0 = js_cb.get_value::<i32>(0)?;
+/// let rust_value_1 = js_cb.get_value::<i32>(1)?;
+/// ```
 mod arg_extraction {
 
     use super::*;
@@ -238,13 +239,15 @@ mod closure {
 
     /// for closure, we need create wrapper closure that translates inner closure
     /// for example, if we have following rust closure
-    ///
-    ///     fn rust_fn<F: Fn(i32)>(cb: F)        
+    /// ```ignore
+    /// fn rust_fn<F: Fn(i32)>(cb: F)
+    /// ```
     ///
     /// we need to invoke in the bindgen code as below
-    ///         let js_cb = js_env.get_cb_info(cb_info,1)?;
-    ///         let rust_value_0 = js_cb.get_value::<JsCallbackFunction>(0)?;
-    ///   
+    /// ```ignore
+    /// let js_cb = js_env.get_cb_info(cb_info,1)?;
+    /// let rust_value_0 = js_cb.get_value::<JsCallbackFunction>(0)?;
+    ///
     ///     rust_fn( move |cb_arg0: i32| {
     ///         let result = (|| {
     ///             let args = vec![cb_arg0];
@@ -252,7 +255,8 @@ mod closure {
     ///         })();
     ///         result.to_js(&js_env)
     ///     }).try_to_js(&js_env)
-    ///                 
+    /// ```
+    ///
     pub fn generate_closure_invocation(
         closure: &ClosureType,
         arg_index: usize,
@@ -434,7 +438,9 @@ mod closure {
 }
 
 /// generate expression to convert napi value to rust value from callback
-/// ```let rust_value_0 = js_cb.get_value_at::<&[u8]>(0)?;```
+/// ```ignore
+/// let rust_value_0 = js_cb.get_value_at::<&[u8]>(0)?;
+/// ```
 fn rust_value(type_name: TokenStream, index: usize) -> TokenStream {
     let arg_index = LitInt::new(&index.to_string(), Span::call_site());
     let rust_value = rust_arg_var(index);

--- a/nj-derive/src/lib.rs
+++ b/nj-derive/src/lib.rs
@@ -10,23 +10,26 @@ use proc_macro::TokenStream;
 /// This turns regular rust function into N-API compatible native module
 ///
 /// For example; given rust following here
-///
-///      fn sum(first: i32, second: i32) -> i32 {
-///           return first+second
-///      }
+/// ```ignore
+/// fn sum(first: i32, second: i32) -> i32 {
+///      return first+second
+/// }
+/// ```
 ///
 /// into N-API module
-///     #[no_mangle]
-///     pub extern "C" fn n_sum(env: napi_env, cb_info: napi_callback_info) -> napi_value {
-///         fn sum(first: i32, second: i32) -> i32 {
-///           return first+second
-///         }
-///         let js_env = JsEnv::new(env);
-///         let js_cb = result_to_napi!(js_env.get_cb_info(cb_info, 2),&js_env);
-///         let first = result_to_napi!(js_cb.get_value::<i32>(0),&js_env);
-///         let second = result_to_napi!(js_cb.get_value::<i32>(0),&js_env);
-///         sum(msg).to_js(&js_env)
+/// ```ignore
+/// #[no_mangle]
+/// pub extern "C" fn n_sum(env: napi_env, cb_info: napi_callback_info) -> napi_value {
+///     fn sum(first: i32, second: i32) -> i32 {
+///       return first+second
 ///     }
+///     let js_env = JsEnv::new(env);
+///     let js_cb = result_to_napi!(js_env.get_cb_info(cb_info, 2),&js_env);
+///     let first = result_to_napi!(js_cb.get_value::<i32>(0),&js_env);
+///     let second = result_to_napi!(js_cb.get_value::<i32>(0),&js_env);
+///     sum(msg).to_js(&js_env)
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn node_bindgen(args: TokenStream, item: TokenStream) -> TokenStream {
     use syn::AttributeArgs;

--- a/nj-derive/ui-tests/pass_class_lifetimes.rs
+++ b/nj-derive/ui-tests/pass_class_lifetimes.rs
@@ -1,0 +1,21 @@
+
+use node_bindgen::derive::node_bindgen;
+
+struct Inner;
+
+struct NamedScopeObject<'a>{
+    val: &'a Option<Inner>,
+}
+
+#[node_bindgen]
+impl NamedScopeObject<'_> {
+    #[node_bindgen(constructor)]
+    fn new() -> Self {
+        Self { val: &None }
+    }
+
+}
+
+fn main() {
+
+}


### PR DESCRIPTION
This closes #124.

I also don't like the variable named `impl_for_block`. It's the `Bar` in `Impl Foo for Bar` but I'm not sure what this grammar item is called. Anyone know what to google for this?

I also updated the the docs to ignore the failing doc tests. I found it simpler to be able to run `cargo test` in the `nj-derive` directory. I can make this a separate PR if we want.