### PR TITLE
Update JSArrayBuffer to be usable in env.convert_to_rust::<JsArrayBuffer>()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build = ["nj-build"]
 
 [dependencies]
 nj-sys = { path = "nj-sys", version = "3.0.0", optional = true }
-nj-core = { path = "nj-core", version = "4.2.0", optional = true  }
+nj-core = { path = "nj-core", version = "4.1.2", optional = true  }
 nj-build = { path = "nj-build", version = "0.2.2", optional = true }
 nj-derive = { path = "nj-derive", version = "3.1.0", optional = true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build = ["nj-build"]
 
 [dependencies]
 nj-sys = { path = "nj-sys", version = "3.0.0", optional = true }
-nj-core = { path = "nj-core", version = "4.1.2", optional = true  }
+nj-core = { path = "nj-core", version = "4.2.0", optional = true  }
 nj-build = { path = "nj-build", version = "0.2.2", optional = true }
 nj-derive = { path = "nj-derive", version = "3.1.0", optional = true}
 

--- a/nj-core/src/buffer.rs
+++ b/nj-core/src/buffer.rs
@@ -115,6 +115,14 @@ pub struct JSArrayBuffer {
     buffer: &'static [u8],
 }
 
+unsafe impl Send for JSArrayBuffer {}
+
+impl JSArrayBuffer {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buffer
+    }
+}
+
 impl JSValue<'_> for JSArrayBuffer {
     fn convert_to_rust(env: &JsEnv, napi_value: napi_value) -> Result<Self, NjError> {
         use std::mem::transmute;


### PR DESCRIPTION
This is required for https://github.com/infinyon/fluvio-client-node/pull/77