### PR TITLE
[Merged by Bors] - Bumped patch version of nj-derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 ### Improvements
 
-## [5.0.0] - TBD
+## [5.0.0] - 2021-07-15
 ### Improvements
 - Added support for automatic conversion of structs and enums into the JS representation by decorating their definition with `#[node_bindgen]` ([#148](https://github.com/infinyon/node-bindgen/pull/148) and [#155](https://github.com/infinyon/node-bindgen/pull/155))
 - Defined a `NjError::Native` Error payload, which allows errors to return structured data to JS

--- a/nj-derive/Cargo.toml
+++ b/nj-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nj-derive"
-version = "3.4.0"
+version = "3.4.1"
 authors = ["fluvio.io"]
 edition = "2018"
 description = "procedure macro for node-bindgen"


### PR DESCRIPTION
In #165, I forgot to bump the version of nj-derive.