### PR TITLE
[Merged by Bors] - Consider prefix in object file (building for windows)

### DIFF
--- a/nj-build/src/lib.rs
+++ b/nj-build/src/lib.rs
@@ -1,69 +1,151 @@
 mod win_delay_load_hook;
 
+#[cfg(windows)]
+mod win {
+    use super::win_delay_load_hook;
+    use std::env::var;
+    use std::fs::{File, remove_file};
+    use http_req::request;
+    use std::{
+        process::Command,
+        env::temp_dir,
+        io,
+        path::{PathBuf},
+        fs::{read_dir, create_dir, DirEntry},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    macro_rules! cargo_warn {
+        ($($tokens: tt)*) => {
+            println!("cargo:warning={}", format!($($tokens)*))
+        }
+    }
+
+    fn print_folder(path: &PathBuf) {
+        match ls(path) {
+            Ok(list) => {
+                list.iter()
+                    .for_each(|entry| cargo_warn!("{:?}", entry.path()));
+            }
+            Err(err) => cargo_warn!("Fail read {path:?}: {err}"),
+        }
+    }
+
+    fn ls(path: &PathBuf) -> Result<Vec<DirEntry>, io::Error> {
+        let mut list = vec![];
+        for entry in read_dir(path)? {
+            list.push(entry?);
+        }
+        Ok(list)
+    }
+
+    fn tmp_folder_name() -> String {
+        format!(
+            "node_bindgen_build_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_nanos()
+        )
+    }
+
+    fn find_file_ends_with(path: &PathBuf, filename: &str) -> Option<String> {
+        let list = ls(path).expect("Get list of files from temp folder");
+        list.iter()
+            .find(|entry| {
+                if let Ok(mt) = entry.metadata() {
+                    if mt.is_file() {
+                        return entry.file_name().to_string_lossy().ends_with(filename);
+                    }
+                }
+                false
+            })
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+    }
+
+    pub fn configure() {
+        // On Windows, we need to download the dynamic library from the nodejs.org website first
+        let node_full_version =
+            String::from_utf8(Command::new("node").arg("-v").output().unwrap().stdout)
+                .unwrap()
+                .trim_end()
+                .to_string();
+
+        let tmp_dir = temp_dir().join(tmp_folder_name());
+        if !tmp_dir.exists() {
+            create_dir(&tmp_dir).expect("Folder {tmp_dir:?} would be created");
+        }
+        let temp_lib = tmp_dir.join(format!("node-{}.lib", node_full_version));
+
+        if !temp_lib.exists() {
+            let lib_file_download_url = format!(
+                "https://nodejs.org/dist/{}/win-x64/node.lib",
+                node_full_version
+            );
+
+            cargo_warn!(
+                "downloading nodejs: {} to: {:#?}",
+                lib_file_download_url,
+                temp_lib
+            );
+
+            let mut node_lib_file = File::create(&temp_lib).unwrap();
+            if let Err(err) = request::get(&lib_file_download_url, &mut node_lib_file) {
+                if temp_lib.exists() {
+                    if let Err(err) = remove_file(&temp_lib) {
+                        cargo_warn!("Fail to remove {:#?} due error: {}", temp_lib, err);
+                    }
+                }
+                panic!("Download node.lib file failed with: {}", err);
+            };
+        }
+
+        println!(
+            "cargo:rustc-link-lib={}",
+            &temp_lib.file_stem().unwrap().to_str().unwrap()
+        );
+        println!("cargo:rustc-link-search={}", tmp_dir.to_str().unwrap());
+
+        // Link `win_delay_load_hook.obj` for windows electron
+        let node_runtime_env = "npm_config_runtime";
+        println!("cargo:rerun-if-env-changed={}", node_runtime_env);
+
+        if var(node_runtime_env).map(|s| s == "electron") == Ok(true) {
+            // Build win_delay_load_hook
+            let mut filename = format!(
+                "{}.o",
+                win_delay_load_hook::build(tmp_dir.clone())
+                    .expect("Failed to build win_delay_load_hook")
+            );
+            let full_filename = tmp_dir.join(&filename);
+            // Checking for object file
+            if !full_filename.exists() {
+                cargo_warn!("File {full_filename:?} doesn't exist");
+                // Drop into logs list of generated files
+                print_folder(&tmp_dir);
+                // It might be a target file is generated, but the name includes a prefix
+                cargo_warn!("Looking for file {filename} with some prefix in {tmp_dir:?}");
+                if let Some(prefix_filename) = find_file_ends_with(&tmp_dir, &filename) {
+                    filename = prefix_filename;
+                    cargo_warn!("Found object file {filename}");
+                } else {
+                    panic!("Fail to find any related object file");
+                }
+            }
+            println!("cargo:rustc-cdylib-link-arg={filename}");
+            println!("cargo:rustc-cdylib-link-arg=delayimp.lib");
+            println!("cargo:rustc-cdylib-link-arg=/DELAYLOAD:node.exe");
+            println!("cargo:rustc-cdylib-link-arg=/INCLUDE:__pfnDliNotifyHook2");
+            println!("cargo:rustc-cdylib-link-arg=/FORCE:MULTIPLE");
+        }
+    }
+}
+
 /// Slightly modified from https://github.com/Brooooooklyn/napi-rs/blob/master/build/src/lib.rs
 /// configure linker to generate node.js dynamic library
 #[cfg(windows)]
 pub fn configure() {
-    // On Windows, we need to download the dynamic library from the nodejs.org website first
-    use std::env::var;
-    use std::fs::{File, remove_file};
-    use http_req::request;
-    use std::process::Command;
-    use std::env::temp_dir;
-
-    let node_full_version =
-        String::from_utf8(Command::new("node").arg("-v").output().unwrap().stdout)
-            .unwrap()
-            .trim_end()
-            .to_string();
-
-    let tmp_dir = temp_dir();
-    let temp_lib = tmp_dir
-        .clone()
-        .join(format!("node-{}.lib", node_full_version));
-
-    if !temp_lib.exists() {
-        let lib_file_download_url = format!(
-            "https://nodejs.org/dist/{}/win-x64/node.lib",
-            node_full_version
-        );
-
-        println!(
-            "downloading nodejs: {} to: {:#?}",
-            lib_file_download_url, temp_lib
-        );
-
-        let mut node_lib_file = File::create(&temp_lib).unwrap();
-        if let Err(err) = request::get(&lib_file_download_url, &mut node_lib_file) {
-            if temp_lib.exists() {
-                if let Err(err) = remove_file(&temp_lib) {
-                    eprintln!("Fail to remove {:#?} due error: {}", temp_lib, err);
-                }
-            }
-            panic!("Download node.lib file failed with: {}", err);
-        };
-    }
-
-    println!(
-        "cargo:rustc-link-lib={}",
-        &temp_lib.file_stem().unwrap().to_str().unwrap()
-    );
-    println!("cargo:rustc-link-search={}", tmp_dir.to_str().unwrap());
-
-    // Link `win_delay_load_hook.obj` for windows electron
-    let node_runtime_env = "npm_config_runtime";
-    println!("cargo:rerun-if-env-changed={}", node_runtime_env);
-
-    if var(node_runtime_env).map(|s| s == "electron") == Ok(true) {
-        // Build win_delay_load_hook
-        win_delay_load_hook::build(tmp_dir).expect("Failed to build win_delay_load_hook");
-
-        println!("cargo:rustc-cdylib-link-arg=win_delay_load_hook.o");
-        println!("cargo:rustc-cdylib-link-arg=delayimp.lib");
-        println!("cargo:rustc-cdylib-link-arg=/DELAYLOAD:node.exe");
-        println!("cargo:rustc-cdylib-link-arg=/INCLUDE:__pfnDliNotifyHook2");
-        println!("cargo:rustc-cdylib-link-arg=/FORCE:MULTIPLE");
-    }
+    win::configure();
 }
 
 #[cfg(unix)]

--- a/nj-build/src/win_delay_load_hook.rs
+++ b/nj-build/src/win_delay_load_hook.rs
@@ -1,5 +1,5 @@
 #[cfg(windows)]
-pub fn build(dir: std::path::PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+pub fn build(dir: std::path::PathBuf) -> Result<String, Box<dyn std::error::Error>> {
     use std::fs::{File, remove_file};
     use std::io::prelude::*;
     use std::env::current_dir;
@@ -65,5 +65,5 @@ pub fn build(dir: std::path::PathBuf) -> Result<(), Box<dyn std::error::Error>> 
     // Remove tmp file once the artifact is built;
     remove_file(&tmp_file)?;
 
-    Ok(())
+    Ok(file_name.to_string())
 }

--- a/nj-derive/src/generator/derive.rs
+++ b/nj-derive/src/generator/derive.rs
@@ -205,7 +205,6 @@ fn generate_variant_conversion(
             let variant_output_arr = format_ident!("variant_output_arr");
             let fields_count = unnamed_fields.len();
             let field_bindings = (0..fields_count)
-                .into_iter()
                 .map(|field_idx| format_ident!("field_{}", field_idx))
                 .collect::<Vec<Ident>>();
 


### PR DESCRIPTION
## Problematic 
With the latest updates `cc` crate (and probably updates related to MS C/C++ build tools) windows build for election failed because it fails to find the object file for `win_delay_load_hook.o`.

Here is a typical error:
```
= note: LINK : fatal error LNK1181: cannot open input file 'win_delay_load_hook.o'
```
More details you can find here: https://github.com/esrlabs/chipmunk/actions/runs/4404226630/jobs/7713572190

The issue is: the compiler creates the object file with a prefix (ex: `xxxxxxxxxxxx-win_delay_load_hook.o`) and as result `cargo` cannot link it and the build fails.

## Suggested solution
- compile stuff not directly into the os temp-folder, but create for each build-iteration temporary folder (based on timestamp); ex: `node_bindgen_build_1234567890`. It will allow isolating files, which are generated by node-bindgen from others. Also, it's quite useful for debugging. 
- as soon as compilation is done, check for `win_delay_load_hook.o`. If the file doesn't exist - check for the same file but with prefix `xxxxxxxxxxxx-win_delay_load_hook.o`. Because compilation happens inside the just created folder it's a safe operation and we can consider the file with a prefix.

## Addition changes
- most times building happens remotely (aka git actions and etc). That's very important to give relevant logs. My suggestion drop warnings with `cargo:warning`. It will reflect problems as well.
- also I suggest listing compiled files in case `win_delay_load_hook.o` hasn't been found.