### PR TITLE
fix: fix edition of nj-build crate

### DIFF
--- a/nj-build/Cargo.toml
+++ b/nj-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nj-build"
 version = "0.3.0"
 authors = ["fluvio.io"]
-edition = "2021"
+edition = "2018"
 description = "build configuration for node-bindgen"
 repository = "https://github.com/infinyon/node-bindgen"
 license = "Apache-2.0"


### PR DESCRIPTION
<del>There is no 2021 edition as far as I can find.</del> Actually there is 2021 edition but not sure why this is failing the release action. https://github.com/infinyon/node-bindgen/actions/runs/6025141849