### PR TITLE
[Merged by Bors] - fix: update  js-env test cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "nj-derive"
-version = "3.4.1"
+version = "3.4.2"
 dependencies = [
  "Inflector",
  "fluvio-future",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "nj-derive"
-version = "3.4.1"
+version = "3.4.2"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,7 +21,7 @@ install:
 
 test: install test-function test-cb test-async-cb test-promise test-json test-class-simple \
 	test-class-wrapper test-class-async test-stream test-buffer test-array test-bigint test-logging\
-	test-cleanup
+	test-cleanup test-jsenv
 
 test-function:
 	make -C function test
@@ -73,6 +73,9 @@ test-logging:
 
 test-cleanup:
 	make -C cleanup test
+
+test-jsenv:
+	make -C js-env test
 
 check-clippy:
 	cargo clippy --all --all-features -- \

--- a/examples/js-env/src/lib.rs
+++ b/examples/js-env/src/lib.rs
@@ -4,10 +4,21 @@ use node_bindgen::core::NjError;
 use node_bindgen::core::val::JsEnv;
 
 /// example where we receive napi callback manually
-/// with napi callback, have full control over JS object lifecycle
-/// JsEnv argument does not manipulate JsCb arguments
+/// in order to do that, we use TryIntoJs trait
 #[node_bindgen]
-fn multiply(env: JsEnv, arg: f64) -> Result<napi_value, NjError> {
+fn double(arg: f64) -> Result<EnvInterceptor, NjError> {
     println!("arg: {arg}");
-    env.create_double(arg * 2.0)
+    Ok(EnvInterceptor(arg))
 }
+
+struct EnvInterceptor(f64);
+
+use node_bindgen::core::TryIntoJs;
+
+impl TryIntoJs for EnvInterceptor {
+    fn try_to_js(self, js_env: &JsEnv) -> Result<napi_value, NjError> {
+        println!("intercepting env");
+        js_env.create_double(self.0 * 2.0)
+    }
+}
+

--- a/examples/js-env/test.js
+++ b/examples/js-env/test.js
@@ -2,4 +2,4 @@ const assert = require('assert');
 
 let addon = require('./dist');
 
-assert.equal(addon.multiply(5), 10);
+assert.equal(addon.double(5), 10);

--- a/nj-derive/Cargo.toml
+++ b/nj-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nj-derive"
-version = "3.4.1"
+version = "3.4.2"
 authors = ["fluvio.io"]
 edition = "2018"
 description = "procedure macro for node-bindgen"

--- a/nj-derive/src/ast/arg.rs
+++ b/nj-derive/src/ast/arg.rs
@@ -136,7 +136,6 @@ pub enum FunctionArgType<'a> {
     Ref(MyReferenceType<'a>), // reference type
     Tuple(MyTupleType<'a>),
     Closure(ClosureType<'a>), // closure callback
-                              // JsEnv(MyReferenceType<'a>),     // indicating that we want to receive JsEnv
 }
 
 /// find generic with match ident

--- a/nj-derive/src/generator/function.rs
+++ b/nj-derive/src/generator/function.rs
@@ -158,6 +158,7 @@ mod arg_extraction {
 
         quote! {
 
+            node_bindgen::core::log::debug!(args = #js_count, "args count");
             let mut js_cb = js_env.get_cb_info(cb_info, #js_count)?;
 
             #(#rust_args)*


### PR DESCRIPTION
resolves #257 

This was nothing do with 18.17 compatibility.  `js-env` test cases were not updated to use the `TryIntoJs`.   Added to Example test suite.
Add more tracing to make it easier to trace conversion