### PR TITLE
[Merged by Bors] - Update the readme to add default-features = false

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ node-bindgen = { version = "6.0" }
 Then add ```node-bindgen```'s procedure macro to your build-dependencies as below:
 ```
 [build-dependencies]
-node-bindgen = { version = "6.0", features = ["build"] }
+node-bindgen = { version = "6.0", default-features = false, features = ["build"] }
 ```
 
 Then update crate type to ```cdylib``` to generate node.js compatible native module:


### PR DESCRIPTION
Without `default-features = false` some Linux users may encounter build issues. The examples have included this in the Cargo.toml files, but if you are like me I copyed from the README while working on MacOS, and then encounterd this issue later on when working on Linux.