### PR TITLE
Update README (add ref to tslink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,58 @@ $ npx electron-build-env nj-cli build --release
 
 otherwise you will get dreaded  `A dynamic link library (DLL) initialization routine failed` when importing the rust module in electron
 
+## Preparing npm packages
+
+Node module generated with `node-bindgen` can be used directly in any node JS project, just copied `index.node` into it. But in case of direct access to a module IDE will not highlight available functions, classes etc. Usually, this is not comfortable and makes the risks of potential bugs higher as soon as the public API of the node module is changed.
+
+To create a full-fledged npm package with TypeScript types definitions and all necessary JavaScript wrappers can be used a crate `tslink`.
+
+`tslink` crate generates files `*.d.ts`, `*.js` and `package.json` with a description of the npm module. Such package could be integrated into an end-project with minimal effort. 
+
+In addition, because `tslink` generates TypeScript types definitions, any changes on the native node module (`index.node`) will be highlighted by `TypeScript` compiler and it makes the risk of bugs (related to changed API or public data types) much lower.
+
+For example,
+
+```ignore
+#[macro_use] extern crate tslink;
+use tslink::tslink;
+use node_bindgen::derive::node_bindgen;
+
+struct MyScruct {}
+
+#[tslink(class)]
+#[node_bindgen]
+impl MyScruct {
+    #[tslink(constructor)]
+    #[node_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    #[tslink(snake_case_naming)]
+    #[node_bindgen]
+    fn inc_my_number(&self, a: i32) -> i32 {
+        a + 1
+    }
+}
+```
+
+Pay your attention, call of `#[tslink]` should be always above of call `#[node_bindgen]`.
+
+Also, please **note**, `node-bindgen` by default applies snake case naming to methods. You should use `#[tslink(snake_case_naming)]` to consider this moment (see more on [crate page](https://docs.rs/tslink/0.1.0/tslink)).
+
+`tslink` requires a configuration file in the root of your project (`tslink.toml`). Configuration file should include a valid path to the native node module. By default `node-bindgen` creates `index.node` in `./dist` folder of your `root`.
+
+File: `./tslink.toml` (in a `root` of project):
+
+```ignore
+node = "./dist/index.node"
+```
+
+Full example of usage `tslink` and `node-bindgen` is [here](https://github.com/DmitryAstafyev/tslink/tree/master/examples/node_bindgen).
+
+See more API documentation on a `tslink` [crate page](https://docs.rs/tslink/0.1.0/tslink).
+
 ## Contributing
 
 If you'd like to contribute to the project, please read our [Contributing guide](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ otherwise you will get dreaded  `A dynamic link library (DLL) initialization rou
 
 Node module generated with `node-bindgen` can be used directly in any node JS project, just copied `index.node` into it. But in case of direct access to a module IDE will not highlight available functions, classes etc. Usually, this is not comfortable and makes the risks of potential bugs higher as soon as the public API of the node module is changed.
 
-To create a full-fledged npm package with TypeScript types definitions and all necessary JavaScript wrappers can be used a crate `tslink`.
+To create a full-fledged npm package with TypeScript types definitions and all necessary JavaScript wrappers can be used a crate [tslink](https://crates.io/crates/tslink).
 
 `tslink` crate generates files `*.d.ts`, `*.js` and `package.json` with a description of the npm module. Such package could be integrated into an end-project with minimal effort. 
 

--- a/README.md
+++ b/README.md
@@ -403,22 +403,33 @@ For example,
 use tslink::tslink;
 use node_bindgen::derive::node_bindgen;
 
-struct MyScruct {}
+struct MyScruct {
+    inc: i32,
+}
 
 #[tslink(class)]
 #[node_bindgen]
 impl MyScruct {
     #[tslink(constructor)]
     #[node_bindgen(constructor)]
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(inc: i32) -> Self {
+        Self { inc }
     }
 
     #[tslink(snake_case_naming)]
     #[node_bindgen]
     fn inc_my_number(&self, a: i32) -> i32 {
-        a + 1
+        a + self.inc
     }
+}
+```
+
+Would be represented (`*.d.ts`) as
+
+```ignore
+export declare class MyStruct {
+    constructor(inc: number);
+    incMyNumber(a: number): number;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ Full example of usage `tslink` and `node-bindgen` is [here](https://github.com/D
 
 See more API documentation on a `tslink` [crate page](https://docs.rs/tslink/0.1.0/tslink).
 
+**Note**. The node-bindgen's developers are not responsible for the correctness of the work tslink crate. All possible issues and feature requests related to tslink should be addressed to tslink's developers.
+
 ## Contributing
 
 If you'd like to contribute to the project, please read our [Contributing guide](CONTRIBUTING.md).


### PR DESCRIPTION
Hello, guys.

I have one suggestion for you and I'm doing it via PR ;)

Since I've been using node-bindgen for a long time already across a couple of projects I found missing TypeScript types a little annoying ).

That's just not comfortable from a testing and developing perspective. 

You know, some small changes in data type on the native module side, and you shouldn't forget to update it on nodejs side too. 

With TypeScript it is much easier. Imagine workflow:
1. generate a native node module
2. generate TypeScript types based on previous
3. include into the end-project as a full-fledged npm package
4. build (with TypeScript compiler) an end-project.

You see? If some changes happen on step 1, on the heights level (nodejs) TypeScript compiler will inform about any errors. It makes a solution more stable and helps with testing indeed. 

I've developed crate [tslink](https://github.com/DmitryAstafyev/tslink) which generates `*.d.ts`, `*.js` and `*.ts` files and actually creates a full-fledged npm package.

As a bonus - code highlights on the IDE level as well.

What do you think about it? 
If you are finding this useful for your users, let's add some remarks about it to your documentation.

P.S.
Combined usage `tslink` and `node-bindgen` is very much covered by tests, you can see it in [repo](https://github.com/DmitryAstafyev/tslink) of the project.
