### PR TITLE
Find library names with auto-converted dash to underscore

### DIFF
--- a/nj-cli/src/main.rs
+++ b/nj-cli/src/main.rs
@@ -168,7 +168,13 @@ fn find_cdylib(package: &Package) -> Option<&Target> {
     package
         .targets
         .iter()
-        .find(|&target| target.name == package.name)
+        .find(|&target| target.name == package.name.replace('-', "_"))
+        .or_else(|| {
+            package
+                .targets
+                .iter()
+                .find(|&target| target.name == package.name)
+        })
 }
 
 fn find_current_package<'a>(metadata: &'a Metadata, manifest_path: &Path) -> Option<&'a Package> {


### PR DESCRIPTION
nj-cli failed on nightly toolchain because a dash was converted to an underscore in the cdylib target name.
This change was introduced in cargo [by this PR](https://github.com/rust-lang/cargo/pull/12783)

Tested the change on nightly and stable.
