### PR TITLE
chore: fix clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,8 @@ jobs:
         rust: [stable]
     steps:
       - uses: actions/checkout@v4
-      - name: Install ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
       - name: check fmt
         run: make check-fmt RUSTV=${{ matrix.rust }}
 
@@ -42,11 +39,8 @@ jobs:
         rust: [stable]
     steps:
       - uses: actions/checkout@v4
-      - name: Install ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
       - name: check clippy
         run: make check-clippy
 
@@ -62,11 +56,8 @@ jobs:
         node-version: [ '16', '18', '20' ]
     steps:
     - uses: actions/checkout@v4
-    - name: Install ${{ matrix.rust }}
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        override: true
+    - name: Install Rust stable
+      uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ check-clippy:	install-clippy check-clippy-examples
 	cargo clippy --all --all-features -- \
 		-D warnings \
 		-A clippy::upper_case_acronyms \
-		-A clippy::needless-question-mark
+		-A clippy::needless-question-mark \
+		-A clippy::macro-metavars-in-unsafe
 
 check-clippy-examples: install-clippy
 	make -C examples check-clippy

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -404,16 +404,27 @@ checksum = "d7bb78c21409e7d24567b9b8a0d880e13ae5ef8fbbfb2a514c3966cd83e078c9"
 dependencies = [
  "anyhow",
  "async-io 1.13.0",
- "async-std",
- "cfg-if",
  "fluvio-wasm-timer",
  "futures-lite 1.13.0",
  "log",
  "pin-project",
  "thiserror",
  "tracing",
- "tracing-subscriber",
  "ws_stream_wasm",
+]
+
+[[package]]
+name = "fluvio-future"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a28090046453db33a8bace0e1f71350b9878cd7fb576e48592ae8284bc83c7e"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "cfg-if",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -766,7 +777,7 @@ version = "6.0.2"
 dependencies = [
  "async-trait",
  "ctor 0.2.8",
- "fluvio-future",
+ "fluvio-future 0.7.0",
  "futures-lite 2.3.0",
  "inventory",
  "libc",
@@ -799,7 +810,7 @@ dependencies = [
 name = "nj-example-async-cb"
 version = "0.0.0"
 dependencies = [
- "fluvio-future",
+ "fluvio-future 0.6.2",
  "node-bindgen",
  "tracing",
 ]
@@ -831,7 +842,7 @@ dependencies = [
 name = "nj-example-class-async"
 version = "0.0.0"
 dependencies = [
- "fluvio-future",
+ "fluvio-future 0.6.2",
  "node-bindgen",
 ]
 
@@ -890,7 +901,7 @@ dependencies = [
 name = "nj-example-option"
 version = "0.0.0"
 dependencies = [
- "fluvio-future",
+ "fluvio-future 0.6.2",
  "node-bindgen",
 ]
 
@@ -905,7 +916,7 @@ dependencies = [
 name = "nj-example-promise"
 version = "0.0.0"
 dependencies = [
- "fluvio-future",
+ "fluvio-future 0.6.2",
  "node-bindgen",
 ]
 
@@ -913,7 +924,7 @@ dependencies = [
 name = "nj-example-stream"
 version = "0.0.0"
 dependencies = [
- "fluvio-future",
+ "fluvio-future 0.6.2",
  "futures-lite 1.13.0",
  "node-bindgen",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,9 +28,9 @@ members = [
 [workspace.dependencies]
 serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.53"
-futures-lite = "1.7.0"
+futures-lite = "2.0.0"
 uuid = "1.8.0"
 tracing = "0.1.37"
 
 node-bindgen = { path = "..", features = ["default"]}
-fluvio-future = { version = "0.6.0", features = ["timer"] }
+fluvio-future = { version = "0.7.0", features = ["timer"] }

--- a/examples/class-async/src/lib.rs
+++ b/examples/class-async/src/lib.rs
@@ -9,6 +9,7 @@ use node_bindgen::core::val::JsEnv;
 use node_bindgen::core::TryIntoJs;
 use node_bindgen::derive::node_bindgen;
 
+#[allow(dead_code)]
 pub struct MyJson {
     val: f64,
 }


### PR DESCRIPTION
update to use  dtolnay/rust-toolchain